### PR TITLE
fix: missing group permissions for config file

### DIFF
--- a/playbook/idr_client.yml
+++ b/playbook/idr_client.yml
@@ -86,7 +86,7 @@
         force: yes
         group: "{{ app_user_group }}"
         owner: root
-        mode: "u=rw,o=r"
+        mode: "ug=rw,o=r"
         src: config.yaml
       become: yes
 


### PR DESCRIPTION
Make the application configuration file writable by users in the application user group.