### PR TITLE
fix: disable apt cache updates

### DIFF
--- a/playbook/idr_client.yml
+++ b/playbook/idr_client.yml
@@ -9,7 +9,7 @@
             name:
               - cron
             state: present
-            update_cache: yes
+            update_cache: no
 
         - name: Add application user group
           ansible.builtin.group:


### PR DESCRIPTION
Fix IDR Client installation issues caused by apt cache update errors. This fix disables apt cache updates during installation and expects that this is done prior to the installation script being invoked.